### PR TITLE
introduce flag to keep log files

### DIFF
--- a/nanoqm/schedule/components.py
+++ b/nanoqm/schedule/components.py
@@ -154,9 +154,10 @@ def store_MOs(
                               dict_input["job_name"])
     # Remove the ascii MO file
     finally:
-        work_dir = promise_qm.archive['work_dir']
-        path_MOs = fnmatch.filter(os.listdir(work_dir), 'mo_*MOLog')[0]
-        os.remove(join(work_dir, path_MOs))
+        if config.remove_log_file:
+            work_dir = promise_qm.archive['work_dir']
+            path_mos = fnmatch.filter(os.listdir(work_dir), 'mo_*MOLog')[0]
+            os.remove(join(work_dir, path_mos))
 
     return dict_input["node_MOs"]
 

--- a/nanoqm/workflows/schemas.py
+++ b/nanoqm/workflows/schemas.py
@@ -163,6 +163,9 @@ dict_general_options = {
     # Deactivate the computation of the orbitals for debugging purposes
     Optional("compute_orbitals", default=True): bool,
 
+    # Flag to remove the log containing the orbitals for debugging purposes
+    Optional("remove_log_file", default=True): bool,
+
     # General settings
     "cp2k_general_settings": schema_cp2k_general_settings
 }


### PR DESCRIPTION
## Change
Allow the user to keep the CP2K `*Log` files containing the molecular orbitals for debugging purposes.