### PR TITLE
Compute both alphas/betas couplings simultaneously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
 # Change Log
 
-# 0.10.3 (Unreleased)
+# 0.10.4 (Unrelease)
+## New
+* Allow to compute both alphas/betas derivative couplings simultaneusly (#275)
+
+
+# 0.10.3 (09/10/2020)
 ## New
 * Template to create B3LYP computations (#269)
 * Add support for derivative couplings for system with more than one spin state (#275)
 
 ## Fixed
-* Fix distribution error (#272)
-* Fix molecular orbital error [in qmflows](https://github.com/SCM-NV/qmflows/pull/213) (#270)
-* multivalue settings issue (#260)
+* Distribution error (#272)
+* Molecular orbital error [in qmflows](https://github.com/SCM-NV/qmflows/pull/213) (#270)
+* Multivalue settings issue (#260)
 * CP2K executable (#264)
 
 # 0.10.1

--- a/nanoqm/schedule/components.py
+++ b/nanoqm/schedule/components.py
@@ -24,7 +24,7 @@ from qmflows.common import InfoMO
 from qmflows.type_hints import PathLike, PromisedObject
 from qmflows.warnings_qmflows import SCF_Convergence_Warning
 
-from ..common import (DictConfig, Matrix, MolXYZ, is_data_in_hdf5,
+from ..common import (DictConfig, Matrix, is_data_in_hdf5,
                       read_cell_parameters_as_array, store_arrays_in_hdf5)
 from .scheduleCP2K import prepare_job_cp2k
 

--- a/nanoqm/schedule/scheduleCoupling.py
+++ b/nanoqm/schedule/scheduleCoupling.py
@@ -77,8 +77,7 @@ def lazy_couplings(
     """
     if config.tracking:
         fixed_phase_overlaps, swaps = compute_the_fixed_phase_overlaps(
-            paths_overlaps, config.path_hdf5, config.project_name,
-            config.enumerate_from, config.nHOMO)
+            paths_overlaps, config)
     else:
         # Do not track the crossings
         mtx_0 = retrieve_hdf5_data(config.path_hdf5, paths_overlaps[0])
@@ -112,8 +111,9 @@ def lazy_couplings(
 
 
 def compute_the_fixed_phase_overlaps(
-        paths_overlaps: List[str], path_hdf5: PathLike, project_name: str,
-        enumerate_from: int, nHOMO: int) -> Tuple[np.ndarray, np.ndarray]:
+        paths_overlaps: List[str], config: DictConfig) -> Tuple[np.ndarray, np.ndarray]:
+    #  path_hdf5: PathLike, project_name: str,
+    # enumerate_from: int, nHOMO: int)
     """Fix the phase of the overlaps.
 
     First track the unavoided crossings between Molecular orbitals and
@@ -122,22 +122,23 @@ def compute_the_fixed_phase_overlaps(
     number_of_frames = len(paths_overlaps)
     # Pasth to the overlap matrices after the tracking
     # and phase correction
-    roots = [join(project_name, f'overlaps_{i}')
-             for i in range(enumerate_from, number_of_frames + enumerate_from)]
+    roots = [join(config.project_name, config.orbitals_type, f'overlaps_{i}')
+             for i in range(config.enumerate_from, number_of_frames + config.enumerate_from)]
     paths_corrected_overlaps = [join(r, 'mtx_sji_t0_corrected') for r in roots]
     # Paths inside the HDF5 to the array containing the tracking of the
     # unavoided crossings
-    path_swaps = join(project_name, 'swaps')
+    path_swaps = join(config.project_name, config.orbitals_type, 'swaps')
 
     # Compute the corrected overlaps if not avaialable in the HDF5
-    if not is_data_in_hdf5(path_hdf5, paths_corrected_overlaps[0]):
-
+    all_data_in_hdf5 = all(is_data_in_hdf5(config.path_hdf5, path_data)
+                           for path_data in (paths_corrected_overlaps[0], path_swaps))
+    if not all_data_in_hdf5:
         # Compute the dimension of the coupling matrix
-        mtx_0 = retrieve_hdf5_data(path_hdf5, paths_overlaps[0])
+        mtx_0 = retrieve_hdf5_data(config.path_hdf5, paths_overlaps[0])
         _, dim = mtx_0.shape
 
         # Read all the Overlaps
-        overlaps = np.stack([retrieve_hdf5_data(path_hdf5, ps)
+        overlaps = np.stack([retrieve_hdf5_data(config.path_hdf5, ps)
                              for ps in paths_overlaps])
 
         # Number of couplings to compute
@@ -147,7 +148,7 @@ def compute_the_fixed_phase_overlaps(
         # and correct the swaps between Molecular Orbitals
         logger.debug("Computing the Unavoided crossings, "
                      "Tracking the crossings between MOs")
-        overlaps, swaps = track_unavoided_crossings(overlaps, nHOMO)
+        overlaps, swaps = track_unavoided_crossings(overlaps, config.nHOMO)
 
         # Compute all the phases taking into account the unavoided crossings
         logger.debug("Computing the phases of the MOs")
@@ -157,16 +158,16 @@ def compute_the_fixed_phase_overlaps(
         fixed_phase_overlaps = correct_phases(overlaps, mtx_phases)
 
         # Store corrected overlaps in the HDF5
-        store_arrays_in_hdf5(path_hdf5, paths_corrected_overlaps,
+        store_arrays_in_hdf5(config.path_hdf5, paths_corrected_overlaps,
                              fixed_phase_overlaps)
 
         # Store the Swaps tracking the crossing
-        store_arrays_in_hdf5(path_hdf5, path_swaps, swaps, dtype=np.int32)
+        store_arrays_in_hdf5(config.path_hdf5, path_swaps, swaps, dtype=np.int32)
     else:
         # Read the corrected overlaps and the swaps from the HDF5
         fixed_phase_overlaps = np.stack(
-            retrieve_hdf5_data(path_hdf5, paths_corrected_overlaps))
-        swaps = retrieve_hdf5_data(path_hdf5, path_swaps)
+            retrieve_hdf5_data(config.path_hdf5, paths_corrected_overlaps))
+        swaps = retrieve_hdf5_data(config.path_hdf5, path_swaps)
 
     return fixed_phase_overlaps, swaps
 

--- a/nanoqm/workflows/schemas.py
+++ b/nanoqm/workflows/schemas.py
@@ -171,7 +171,7 @@ dict_general_options = {
 
     # Empty string for restricted calculation or either alpha/beta
     # for unrestricted calculation
-    Optional("orbitals_type", default=""): any_lambda(("", "alphas", "betas"))
+    Optional("orbitals_type", default=""): any_lambda(("", "alphas", "betas", "both"))
 }
 
 #: Dict with input options to run a derivate coupling workflow

--- a/nanoqm/workflows/workflow_coupling.py
+++ b/nanoqm/workflows/workflow_coupling.py
@@ -17,7 +17,7 @@ import os
 import shutil
 from os.path import join
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, Union
 
 from noodles import gather, schedule, unpack
 
@@ -33,17 +33,32 @@ from .initialization import initialize
 # Starting logger
 logger = logging.getLogger(__name__)
 
+#: Type defining the derivative couplings calculation
+ResultPaths = Tuple[List[str], List[str]]
 
-def workflow_derivative_couplings(config: DictConfig) -> Tuple[List[str], List[str]]:
+
+def workflow_derivative_couplings(config: DictConfig) -> Union[ResultPaths, Tuple[ResultPaths, ResultPaths]]:
     """Compute the derivative couplings for a molecular dynamic trajectory."""
     # Dictionary containing the general configuration
     config.update(initialize(config))
 
-    logger.info("starting couplings calculation!")
+    if config.orbitals_type != "both":
+        logger.info("starting couplings calculation!")
+        return run_workflow_couplings(config)
+    else:
+        config.orbitals_type = "alphas"
+        logger.info("starting couplings calculation for alphas!")
+        alphas = run_workflow_couplings(config)
+        config.orbitals_type = "betas"
+        logger.info("starting couplings calculation for betas!")
+        betas = run_workflow_couplings(config)
+        return alphas, betas
 
+
+def run_workflow_couplings(config: DictConfig) -> ResultPaths:
+    """Run the derivative coupling workflow using `config`."""
     # compute the molecular orbitals
     mo_paths_hdf5, energy_paths_hdf5 = unpack(calculate_mos(config), 2)
-
 
     # Overlap matrix at two different times
     promised_overlaps = calculate_overlap(config, mo_paths_hdf5)
@@ -52,7 +67,7 @@ def workflow_derivative_couplings(config: DictConfig) -> Tuple[List[str], List[s
     promised_crossing_and_couplings = lazy_couplings(config, promised_overlaps)
 
     # Write the results in PYXAID format
-    config.path_hamiltonians = create_path_hamiltonians(config.workdir)
+    config.path_hamiltonians = create_path_hamiltonians(config.workdir, config.orbitals_type)
 
     # Inplace scheduling of write_hamiltonians function.
     # Equivalent to add @schedule on top of the function
@@ -73,9 +88,11 @@ def workflow_derivative_couplings(config: DictConfig) -> Tuple[List[str], List[s
     return results
 
 
-def create_path_hamiltonians(workdir: PathLike) -> PathLike:
+def create_path_hamiltonians(workdir: PathLike, orbitals_type: str) -> PathLike:
     """Create the Paths to store the resulting hamiltonians."""
-    path_hamiltonians = join(workdir, 'hamiltonians')
+    prefix = "hamiltonias"
+    name = prefix if not orbitals_type else f"{orbitals_type}_{prefix}"
+    path_hamiltonians = join(workdir, name)
     if not os.path.exists(path_hamiltonians):
         os.makedirs(path_hamiltonians)
 

--- a/test/test_files/input_couplings_both.yml
+++ b/test/test_files/input_couplings_both.yml
@@ -5,7 +5,7 @@ active_space: [2, 2]
 path_hdf5: "test/test_files/oxygen.hdf5"
 path_traj_xyz: "test/test_files/O2_coupling.xyz"
 scratch_path: "/tmp/namd"
-orbitals_type: betas
+orbitals_type: both
 
 cp2k_general_settings:
   basis:  "DZVP-MOLOPT-SR-GTH"


### PR DESCRIPTION
## Background
Following feature requested at #275 it is also desired to compute both `alphas/betas` orbitals simultaneously using the keyword
```yaml
orbitals_type: both  # could be one of:  "", "both", "alphas", "betas"
```
