### PR TITLE
Do not remove the point folder wher ethe CP2K orbitals are stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Changed
 * Do not remove the CP2K log files by default
+* Do not remove the point folder wher ethe CP2K orbitals are stored
 
 
 # 0.10.3 (09/10/2020)

--- a/nanoqm/workflows/workflow_coupling.py
+++ b/nanoqm/workflows/workflow_coupling.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 from noodles import gather, schedule, unpack
-
 from qmflows import run
 from qmflows.type_hints import PathLike
 
@@ -83,8 +82,6 @@ def run_workflow_couplings(config: DictConfig) -> ResultPaths:
     results = run(
         gather(promise_files, energy_paths_hdf5), folder=config.workdir, always_cache=False)
 
-    remove_folders(config.folders)
-
     return results
 
 
@@ -97,10 +94,3 @@ def create_path_hamiltonians(workdir: PathLike, orbitals_type: str) -> PathLike:
         os.makedirs(path_hamiltonians)
 
     return path_hamiltonians
-
-
-def remove_folders(folders: List[PathLike]) -> None:
-    """Remove unused folders."""
-    for f in folders:
-        if Path(f).exists():
-            shutil.rmtree(f)


### PR DESCRIPTION
If a workflows stops (e.g. due to time limit in a queue system) when restarting the computations CP2K needs that the folder where the orbitals are going to be stored exists. But currently those folders are been deleted at the end of the workflow but there is not guarantee that the workflow has finished correctly, therefore it is better to keep the point  folder and leave the responsibility to delete them to the user.