### PR TITLE
don't raise error if scratch folder exists

### DIFF
--- a/nanoqm/workflows/initialization.py
+++ b/nanoqm/workflows/initialization.py
@@ -62,7 +62,7 @@ def initialize(config: DictConfig) -> DictConfig:
 
     # If the directory does not exist create it
     if not scratch_path.exists():
-        scratch_path.mkdir(parents=True)
+        scratch_path.mkdir(parents=True, exist_ok=True)
 
     # Touch HDF5 if it doesn't exists
     if not os.path.exists(config.path_hdf5):


### PR DESCRIPTION
## The problem
For some reason in system with [NFS](https://en.wikipedia.org/wiki/Network_File_System) the `scratch_path` folder creation raises an error even though the folder doesn't exists. 