### PR TITLE
REV: Reintroduce parsing of the `potential` and `basis` keys

### DIFF
--- a/nanoqm/schedule/scheduleCP2K.py
+++ b/nanoqm/schedule/scheduleCP2K.py
@@ -110,6 +110,11 @@ def prepare_job_cp2k(
     """
     job_settings = prepare_cp2k_settings(settings, dict_input, guess_job)
 
+    # remove keywords not use on the next translation phase
+    for x in ('basis', 'potential'):
+        if x in job_settings:
+            del job_settings[x]
+
     return cp2k(
         job_settings, string_to_plams_Molecule(dict_input["geometry"]),
         work_dir=dict_input['point_dir'])

--- a/scripts/qmflows/coordination_ldos.py
+++ b/scripts/qmflows/coordination_ldos.py
@@ -12,6 +12,8 @@ from nanoCAT.recipes import coordination_number
 from qmflows import Settings, cp2k, run, templates
 from scm.plams import Molecule
 
+from nanoqm.workflows.templates import generate_kinds
+
 #: A nested dictonary
 NestedDict = Dict[str, Dict[int, List[int]]]
 
@@ -49,6 +51,14 @@ def create_cp2k_settings(mol: Molecule) -> Settings:
 
     # functional
     s.specific.cp2k.force_eval.dft.xc["xc_functional pbe"] = {}
+
+    # Generate kinds for the atom types
+    elements = [x.symbol for x in mol.atoms]
+    kinds = generate_kinds(elements, s.basis, s.potential)
+
+    # Update the setting with the kinds
+    s.specific = s.specific + kinds
+
     return s
 
 

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ setup(
         'schema',
         'pyyaml>=5.1',
         'plams>=1.5.1',
-        'qmflows>=0.11.1',
+        'qmflows>=0.11.0',
     ],
     cmdclass={'build_ext': BuildExt},
     ext_modules=[ext_pybind],

--- a/test/test_input_validation.py
+++ b/test/test_input_validation.py
@@ -58,6 +58,28 @@ class TestInputValidation:
         dft2 = s_output.cp2k_general_settings.cp2k_settings_main.specific.cp2k.force_eval.dft
         assert dft2["basis_set_file_name" if key == "basis_file_name" else key] == ref
 
+    def test_basis(self) -> None:
+        with open(PATH_TEST / "input_test_pbe0.yml", "r") as f:
+            s = plams.Settings(yaml.load(f, Loader=yaml.SafeLoader))
+            s.cp2k_general_settings.basis = "DZVP-MOLOPT-MGGA-GTH"
+            s.cp2k_general_settings.potential = "GTH-MGGA"
+
+        s_out = schema_workflows["derivative_couplings"].validate(s)
+        InputSanitizer(s_out).sanitize()
+
+        ref = {
+            "C": {
+                "basis_set": ["DZVP-MOLOPT-MGGA-GTH-q4", "AUX_FIT CFIT3"],
+                "potential": "GTH-MGGA-q4",
+            },
+            "H": {
+                "basis_set": ["DZVP-MOLOPT-MGGA-GTH-q1", "AUX_FIT CFIT3"],
+                "potential": "GTH-MGGA-q1",
+            },
+        }
+        kind = s_out.cp2k_general_settings.cp2k_settings_main.specific.cp2k.force_eval.subsys.kind
+        assert kind == ref
+
 
 @pytest.mark.skipif(
     not cp2k_available(), reason="CP2K is not install or not loaded")

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -17,4 +17,4 @@ scipy
 schema
 pyyaml>=5.1
 plams>=1.5.1
-qmflows>=0.11.1
+qmflows>=0.11.0


### PR DESCRIPTION
Reverts https://github.com/SCM-NV/nano-qmflows/pull/344/commits/91e80519e4c9ddd46c4226bb286af0269692408c.

Revert to the old behavior, as a number of CP2K potentials and basis sets are reliant on automatically appending `-q([0-9]+)` to the basis set/potential name.

