### PR TITLE
BUG: Do not hard-code the `BASIS_MOLOPT` coefficients in the .hdf5 file

### DIFF
--- a/nanoqm/workflows/initialization.py
+++ b/nanoqm/workflows/initialization.py
@@ -95,9 +95,16 @@ def initialize(config: DictConfig) -> DictConfig:
 
 def save_basis_to_hdf5(config: DictConfig) -> None:
     """Store the specification of the basis set in the HDF5 to compute the integrals."""
-    path_basis = pkg_resources.resource_filename("nanoqm", "basis/BASIS_MOLOPT")
-    if not is_data_in_hdf5(config.path_hdf5, path_basis):
-        store_cp2k_basis(config.path_hdf5, path_basis)
+    root: str = config['cp2k_general_settings']['path_basis']
+    files: "None | list[str]" = config['cp2k_general_settings']['basis_file_name']
+    if files is not None:
+        basis_paths = [os.path.join(root, i) for i in files]
+    else:
+        basis_paths = [os.path.join(root, "BASIS_MOLOPT")]
+
+    for path in basis_paths:
+        if not is_data_in_hdf5(config.path_hdf5, path):
+            store_cp2k_basis(config.path_hdf5, path)
 
 
 def store_cp2k_basis(path_hdf5: PathLike, path_basis: PathLike) -> None:

--- a/test/test_input_validation.py
+++ b/test/test_input_validation.py
@@ -6,13 +6,14 @@ import yaml
 import pytest
 from qmflows import cp2k, run
 from qmflows.type_hints import PathLike
+from qmflows.packages.cp2k_package import CP2K_Result
 from scm import plams
 
 import nanoqm
 from nanoqm.common import read_cell_parameters_as_array
 from nanoqm.workflows.input_validation import process_input, schema_workflows, InputSanitizer
 
-from .utilsTest import PATH_TEST, cp2k_available, remove_files
+from .utilsTest import PATH_TEST, cp2k_available, remove_files, validate_status
 
 
 class TestInputValidation:
@@ -86,13 +87,14 @@ class TestInputValidation:
 def test_call_cp2k_pbe() -> None:
     """Check if the input for a PBE cp2k job is valid."""
     try:
-        results = run_plams(PATH_TEST / "input_test_pbe.yml")
-        assert (results is not None)
+        result = run_plams(PATH_TEST / "input_test_pbe.yml")
+        validate_status(result)
+        assert result.energy is not None
     finally:
         remove_files()
 
 
-def run_plams(path_input: PathLike) -> float:
+def run_plams(path_input: PathLike) -> CP2K_Result:
     """Call Plams to run a CP2K job."""
     # create settings
     dict_input = process_input(path_input, "derivative_couplings")
@@ -107,4 +109,4 @@ def run_plams(path_input: PathLike) -> float:
         # Run the job
     job = cp2k(sett, plams.Molecule(PATH_TEST / "C.xyz"))
 
-    return run(job.energy)
+    return run(job)

--- a/test/utilsTest.py
+++ b/test/utilsTest.py
@@ -1,4 +1,6 @@
 """Functions use for testing."""
+
+import textwrap
 import fnmatch
 import os
 import shutil
@@ -9,8 +11,16 @@ from typing import Union
 
 import h5py
 import pkg_resources as pkg
+from qmflows.packages.packages import Result
 
-__all__ = ["PATH_NANOQM", "PATH_TEST", "copy_basis_and_orbitals", "cp2k_available", "remove_files"]
+__all__ = [
+    "PATH_NANOQM",
+    "PATH_TEST",
+    "copy_basis_and_orbitals",
+    "cp2k_available",
+    "remove_files",
+    "validate_status",
+]
 
 # Environment data
 PATH_NANOQM = Path(pkg.resource_filename('nanoqm', ''))
@@ -33,3 +43,60 @@ def cp2k_available(executable: str = "cp2k.popt") -> bool:
     path = find_executable(executable)
 
     return path is not None
+
+
+def _read_result_file(result: Result, extension: str, max_line: int = 100) -> "None | str":
+    """Find and read the first file in ``result`` with the provided file extension.
+
+    Returns ``None`` if no such file can be found.
+    """
+    root = result.archive["plams_dir"]
+    if root is None:
+        return None
+
+    iterator = (os.path.join(root, i) for i in os.listdir(root)
+                if os.path.splitext(i)[1] == extension)
+    for i in iterator:
+        with open(i, "r") as f:
+            ret_list = f.readlines()
+            ret = "..." if len(ret_list) > max_line else ""
+            ret += "".join(ret_list[-max_line:])
+            return textwrap.indent(ret, 4 * " ")
+    else:
+        return None
+
+
+def validate_status(result: Result, *, print_out: bool = True, print_err: bool = True) -> None:
+    """Validate the status of the ``qmflows.Result`` object is set to ``"successful"``.
+
+    Parameters
+    ----------
+    result : qmflows.Result
+        The to-be validated ``Result`` object.
+    print_out : bool
+        Whether to included the content of the ``Result`` objects' .out file in the exception.
+    print_err : bool
+        Whether to included the content of the ``Result`` objects' .err file in the exception.
+
+    Raises
+    ------
+    AssertionError
+        Raised when :code:`result.status != "successful"`.
+
+    """
+    # TODO: Import `validate_status` from qmflows once 0.11.2 has been release
+    if result.status == "successful":
+        return None
+
+    indent = 4 * " "
+    msg = f"Unexpected {result.job_name} status: {result.status!r}"
+
+    if print_out:
+        out = _read_result_file(result, ".out")
+        if out is not None:
+            msg += f"\n\nout_file:\n{out}"
+    if print_err:
+        err = _read_result_file(result, ".err")
+        if err is not None:
+            msg += f"\n\nerr_file:\n{err}"
+    raise AssertionError(msg)


### PR DESCRIPTION
Follow up on https://github.com/SCM-NV/nano-qmflows/pull/347.

Respect the values of `path_basis` and `basis_file_name` when reading basis set coefficients.