### PR TITLE
ENH: Allow the use of basis sets consisting of multiple exponent sets part 2/2

### DIFF
--- a/libint/compute_integrals.pyi
+++ b/libint/compute_integrals.pyi
@@ -6,7 +6,6 @@ def compute_integrals_couplings(
     __path_xyz_2: str,
     __path_hdf5: str,
     __basis_name: str,
-    __exp_set: int,
 ) -> npt.NDArray[np.float64]: ...
 
 def compute_integrals_multipole(
@@ -14,5 +13,4 @@ def compute_integrals_multipole(
     __path_xyz_2: str,
     __basis_name: str,
     __multipole: str,
-    __exp_set: int,
 ) -> npt.NDArray[np.float64]: ...

--- a/nanoqm/integrals/multipole_matrices.py
+++ b/nanoqm/integrals/multipole_matrices.py
@@ -117,11 +117,11 @@ def compute_matrix_multipole(
 
     if multipole == 'overlap':
         matrix_multipole = compute_integrals_multipole(
-            path, path_hdf5, basis_name, multipole, 0)
+            path, path_hdf5, basis_name, multipole)
     elif multipole == 'dipole':
         # The tensor contains the overlap + {x, y, z} dipole matrices
         super_matrix = compute_integrals_multipole(
-            path, path_hdf5, basis_name, multipole, 0)
+            path, path_hdf5, basis_name, multipole)
         dim = super_matrix.shape[1]
 
         # Reshape the super_matrix as a tensor containing overlap + {x, y, z} dipole matrices
@@ -131,7 +131,7 @@ def compute_matrix_multipole(
         # The tensor contains the overlap + {xx, xy, xz, yy, yz, zz} quadrupole matrices
         print("super_matrix: ", path, path_hdf5, basis_name, multipole)
         super_matrix = compute_integrals_multipole(
-            path, path_hdf5, basis_name, multipole, 0)
+            path, path_hdf5, basis_name, multipole)
         dim = super_matrix.shape[1]
 
         # Reshape to 3d tensor containing overlap + {x, y, z} + {xx, xy, xz, yy, yz, zz} quadrupole matrices

--- a/nanoqm/integrals/nonAdiabaticCoupling.py
+++ b/nanoqm/integrals/nonAdiabaticCoupling.py
@@ -241,7 +241,7 @@ def calcOverlapMtx(config: DictConfig, molecules: Tuple[MolXYZ, MolXYZ]) -> Matr
     basis_name = config["cp2k_general_settings"]["basis"]
     try:
         integrals = compute_integrals_couplings(
-            path_i, path_j, config["path_hdf5"], basis_name, 0)
+            path_i, path_j, config["path_hdf5"], basis_name)
     finally:
         os.remove(path_i)
         os.remove(path_j)


### PR DESCRIPTION
Follow up on https://github.com/SCM-NV/nano-qmflows/pull/362

Adds full support for he use of basis sets such as BASIS_ADMM_MOLOPT.

The big change introduced in this PR is that iteration over all exponent sets now happens automatically.