### PR TITLE
DEP: Remove deprecated pkg_resources API

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         if: matrix.buildplat[1] == 'manylinux_aarch64'
@@ -217,6 +219,8 @@ jobs:
       QMFLOWS_LIBDIR: ""
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -57,6 +57,8 @@ jobs:
             special: ["pre-release", ""]
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Install CP2K
       run: |
@@ -138,6 +140,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.13

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 .installed.cfg
 *.egg
 /tmp
+nanoqm/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/nanoqm/_version.py
+++ b/nanoqm/_version.py
@@ -1,3 +1,0 @@
-"""The Nano-QMFlows version."""
-
-__version__ = '0.14.1.dev0'

--- a/nanoqm/workflows/schemas.py
+++ b/nanoqm/workflows/schemas.py
@@ -19,10 +19,10 @@ from numbers import Real
 from collections.abc import Iterable
 from typing import Any
 
-import pkg_resources as pkg
 from schema import And, Optional, Or, Regex, Schema, Use
 from qmflows import Settings
 
+from .. import __file__ as _nanoqm_file
 from .. import _data
 
 __all__ = [
@@ -117,7 +117,10 @@ schema_cp2k_general_settings = _DataSchema({
     Optional("cell_angles", default=None): list,
 
     # Path to the folder containing the basis set specifications
-    Optional("path_basis", default=pkg.resource_filename("nanoqm", "basis")): os.path.isdir,
+    Optional(
+        "path_basis",
+        default=os.path.join(os.path.dirname(_nanoqm_file), 'basis'),
+    ): os.path.isdir,
 
     # Name(s) of the basis set file(s) stored in ``path_basis``
     Optional("basis_file_name", default=None): Use(_parse_filenames),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,16 @@ requires = [
     'oldest-supported-numpy',
 ]
 
+[project]
+name = "nano-qmflows"
+dynamic = ["dependencies", "optional-dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["install_requirements.txt"] }
+optional-dependencies.test = { file = ["test_requirements.txt"] }
+optional-dependencies.doc = { file = ["doc_requirements.txt"] }
+optional-dependencies.lint = { file = ["linting_requirements.txt"] }
+
 [tool.mypy]
 plugins = "numpy.typing.mypy_plugin"
 show_error_codes = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,28 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    'setuptools>=48.0',
-    'wheel>=0.21',
-    'oldest-supported-numpy',
+    "setuptools>=48.0",
+    "wheel>=0.21",
+    "oldest-supported-numpy",
+    "setuptools_scm[toml]>=6.2",
 ]
 
 [project]
 name = "nano-qmflows"
-dynamic = ["dependencies", "optional-dependencies"]
+dynamic = [
+    "dependencies",
+    "optional-dependencies",
+    "version",
+]
 
 [tool.setuptools.dynamic]
 dependencies = { file = ["install_requirements.txt"] }
 optional-dependencies.test = { file = ["test_requirements.txt"] }
 optional-dependencies.doc = { file = ["doc_requirements.txt"] }
 optional-dependencies.lint = { file = ["linting_requirements.txt"] }
+
+[tool.setuptools_scm]
+write_to = "nanoqm/_version.py"
 
 [tool.mypy]
 plugins = "numpy.typing.mypy_plugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools>=48.0",
+    "setuptools>=61.0",
     "wheel>=0.21",
     "oldest-supported-numpy",
     "setuptools_scm[toml]>=6.2",
 ]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "nano-qmflows"
@@ -13,6 +14,52 @@ dynamic = [
     "dependencies",
     "optional-dependencies",
     "version",
+    "readme",
+]
+description = "Derivative coupling calculation"
+license = { text = "Apache-2.0" }
+authors = [
+    { name = "Felipe Zapata & Ivan Infante", email = "f.zapata@esciencecenter.nl" },
+]
+keywords = [
+    "chemistry",
+    "Photochemistry",
+    "Simulation",
+]
+classifiers = [
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Operating System :: MacOS",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: C++",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Typing :: Typed",
+]
+requires-python = ">=3.8"
+
+[tool.setuptools]
+license-files = ["LICENSE*.txt"]
+
+[tool.setuptools.packages.find]
+exclude = ["test"]
+
+[tool.setuptools.package-data]
+nanoqm = [
+    "basis/*.json",
+    "basis/BASIS*",
+    "basis/GTH_POTENTIALS",
+    "py.typed",
+    "*.pyi",
 ]
 
 [tool.setuptools.dynamic]
@@ -20,6 +67,7 @@ dependencies = { file = ["install_requirements.txt"] }
 optional-dependencies.test = { file = ["test_requirements.txt"] }
 optional-dependencies.doc = { file = ["doc_requirements.txt"] }
 optional-dependencies.lint = { file = ["linting_requirements.txt"] }
+readme = { file = ["README.rst"], content-type = "text/x-rst" }
 
 [tool.setuptools_scm]
 write_to = "nanoqm/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -13,15 +13,6 @@ from setuptools.command.build_ext import build_ext
 from wheel.bdist_wheel import bdist_wheel
 
 
-def get_version() -> str:
-    """Load the version."""
-    here = os.path.abspath(os.path.dirname(__file__))
-    version: "dict[str, str]" = {}
-    with open(os.path.join(here, 'nanoqm', '_version.py'), 'r', encoding='utf8') as f:
-        exec(f.read(), version)
-    return version["__version__"]
-
-
 def get_readme() -> str:
     """Load readme."""
     with open('README.rst', 'r', encoding='utf8') as f:
@@ -149,7 +140,6 @@ libint_ext = Extension(
 
 setup(
     name='nano-qmflows',
-    version=get_version(),
     description='Derivative coupling calculation',
     license='Apache-2.0',
     license_files=["LICENSE*.txt"],

--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,9 @@ from os.path import join
 import setuptools  # noqa: F401
 
 import numpy as np
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from wheel.bdist_wheel import bdist_wheel
-
-
-def get_readme() -> str:
-    """Load readme."""
-    with open('README.rst', 'r', encoding='utf8') as f:
-        return f.read()
 
 
 def is_macos_arm64() -> bool:
@@ -139,47 +133,14 @@ libint_ext = Extension(
 )
 
 setup(
-    name='nano-qmflows',
-    description='Derivative coupling calculation',
-    license='Apache-2.0',
-    license_files=["LICENSE*.txt"],
-    url='https://github.com/SCM-NV/nano-qmflows',
-    author='Felipe Zapata & Ivan Infante',
-    author_email='f.zapata@esciencecenter.nl',
-    keywords='chemistry Photochemistry Simulation',
-    long_description=get_readme() + '\n\n',
-    long_description_content_type='text/x-rst',
-    packages=find_packages(exclude=["test"]),
-    classifiers=[
-        'License :: OSI Approved :: Apache Software License',
-        'Natural Language :: English',
-        'Operating System :: MacOS',
-        'Operating System :: POSIX :: Linux',
-        'Programming Language :: C++',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Science/Research',
-        'Topic :: Scientific/Engineering :: Chemistry',
-        'Typing :: Typed',
-    ],
     cmdclass={'build_ext': BuildExt, "bdist_wheel": BDistWheelABI3},
-    python_requires='>=3.8',
     ext_modules=[libint_ext],
-    package_data={
-        'nanoqm': ['basis/*.json', 'basis/BASIS*', 'basis/GTH_POTENTIALS', 'py.typed', '*.pyi']
-    },
+    url="https://github.com/SCM-NV/nano-qmflows",
     entry_points={
         'console_scripts': [
             'run_workflow.py=nanoqm.workflows.run_workflow:main',
-            'distribute_jobs.py=nanoqm.workflows.distribute_jobs:main'
-        ]
+            'distribute_jobs.py=nanoqm.workflows.distribute_jobs:main',
+        ],
     },
     scripts=[
         'scripts/convert_legacy_hdf5.py',
@@ -195,5 +156,5 @@ setup(
         'scripts/qmflows/removeHDF5folders.py',
         'scripts/qmflows/remove_mos_hdf5.py',
         'scripts/qmflows/convolution.py'
-    ]
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import platform
 from os.path import join
 
 import setuptools  # noqa: F401
-import pkg_resources
+
 import numpy as np
 from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
@@ -81,12 +81,6 @@ class BDistWheelABI3(bdist_wheel):
             return "cp38", "abi3", plat
         else:
             return python, abi, plat
-
-
-def parse_requirements(path: "str | os.PathLike[str]") -> "list[str]":
-    """Parse a ``requirements.txt`` file."""
-    with open(path, "r", encoding="utf8") as f:
-        return [str(i) for i in pkg_resources.parse_requirements(f)]
 
 
 def get_paths() -> "tuple[list[str], list[str]]":
@@ -185,15 +179,9 @@ setup(
         'Topic :: Scientific/Engineering :: Chemistry',
         'Typing :: Typed',
     ],
-    install_requires=parse_requirements("install_requirements.txt"),
     cmdclass={'build_ext': BuildExt, "bdist_wheel": BDistWheelABI3},
     python_requires='>=3.8',
     ext_modules=[libint_ext],
-    extras_require={
-        'test': parse_requirements("test_requirements.txt"),
-        'doc': parse_requirements("doc_requirements.txt"),
-        'lint': parse_requirements("linting_requirements.txt"),
-    },
     package_data={
         'nanoqm': ['basis/*.json', 'basis/BASIS*', 'basis/GTH_POTENTIALS', 'py.typed', '*.pyi']
     },

--- a/test/test_read_cp2k_basis.py
+++ b/test/test_read_cp2k_basis.py
@@ -2,17 +2,18 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
 import numpy as np
 import yaml
 import h5py
-import pkg_resources
 from nanoutils import RecursiveKeysView, RecursiveItemsView
 from packaging.version import Version
 from assertionlib import assertion
 
+import nanoqm
 from nanoqm.workflows.initialization import store_cp2k_basis
 from .utilsTest import PATH_TEST
 
@@ -24,8 +25,11 @@ class TestRedCP2KBasis:
         with h5py.File(tmp_hdf5, "x"):
             pass
 
-        path_basis = pkg_resources.resource_filename(
-            "nanoqm", "basis/BASIS_MOLOPT")
+        path_basis = os.path.join(
+            os.path.dirname(nanoqm.__file__),
+            'basis',
+            'BASIS_MOLOPT',
+        )
 
         store_cp2k_basis(tmp_hdf5, path_basis)
 


### PR DESCRIPTION
There's been quite a number of changes in setuptools as of recent, including deprecation of `pkg_resources` API as used by nano-qmflows. The offending API uses have now been removed.